### PR TITLE
Add burn method

### DIFF
--- a/src/eToken.mvir
+++ b/src/eToken.mvir
@@ -39,7 +39,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -196,7 +196,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import Transaction.Capability;
@@ -219,6 +219,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -257,7 +266,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;

--- a/testscripts/1_owner_can_mint_and_amount_correct.mvir
+++ b/testscripts/1_owner_can_mint_and_amount_correct.mvir
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
@@ -9,7 +9,7 @@
 //          (2) Alice claims ownership by publishing the modules
 //          (3) Alice can grant herself the power of minting
 //          (4) Alice can mint, and the amount is correct
-//          (5) Alice mint again, and check the amount is correct    
+//          (5) Alice mint again, and check the amount is correct
 
 //! account: alice
 //! account: bob
@@ -59,7 +59,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -220,7 +220,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -243,6 +243,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -281,7 +290,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -344,7 +353,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
+    assert(move(balance) == 100, 4);
     return;
 }
 
@@ -385,7 +394,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 4);    
+    assert(move(balance) == 200, 4);
     return;
 }
 
@@ -401,6 +410,6 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 1);    
+    assert(move(balance) == 200, 1);
     return;
 }

--- a/testscripts/2_new_user_can_publish_from_owner_and_balance_is_0.mvir
+++ b/testscripts/2_new_user_can_publish_from_owner_and_balance_is_0.mvir
@@ -1,10 +1,10 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
-// This set of transaction tests the following scenario: 
-//      After the owner Alice has published the module, 
+// This set of transaction tests the following scenario:
+//      After the owner Alice has published the module,
 //      a regular user Bob can also publish the module from Alice's account.
 //      The initial balance of Bob should be 0.
 
@@ -57,7 +57,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -218,7 +218,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -241,6 +241,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -279,7 +288,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -341,13 +350,13 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
+    assert(move(balance) == 100, 4);
     return;
 }
 
 //! new-transaction
 //! sender: bob
-// Bob publishes EToken and Capability under his account. 
+// Bob publishes EToken and Capability under his account.
 
 import {{alice}}.Capability;
 import {{alice}}.EToken;
@@ -372,6 +381,6 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 0, 1);    
+    assert(move(balance) == 0, 1);
     return;
 }

--- a/testscripts/3_token_can_be_transferred.mvir
+++ b/testscripts/3_token_can_be_transferred.mvir
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
@@ -55,7 +55,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -216,7 +216,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -239,6 +239,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -277,7 +286,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -381,7 +390,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 4);    
+    assert(move(balance) == 200, 4);
     return;
 }
 
@@ -397,13 +406,13 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 1);    
+    assert(move(balance) == 200, 1);
     return;
 }
 
 //! new-transaction
 //! sender: bob
-// Bob publishes EToken and Capability under his account. 
+// Bob publishes EToken and Capability under his account.
 
 import {{alice}}.Capability;
 import {{alice}}.EToken;
@@ -428,7 +437,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 0, 1);    
+    assert(move(balance) == 0, 1);
     return;
 }
 
@@ -465,7 +474,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 101, 1);    
+    assert(move(balance) == 101, 1);
     return;
 }
 
@@ -481,6 +490,6 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 99, 1);    
+    assert(move(balance) == 99, 1);
     return;
 }

--- a/testscripts/4_transfer_more_than_balance_should_fail.mvir
+++ b/testscripts/4_transfer_more_than_balance_should_fail.mvir
@@ -1,11 +1,11 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
-// This set of transaction tests the following scenario: 
+// This set of transaction tests the following scenario:
 //      Alice mints some coin and tries to transfer even more to Bob.
-//      This transfer should fail on the line: 
+//      This transfer should fail on the line:
 //                          assert(copy(value) >= copy(amount), 3);
 //      in the function withdraw()
 
@@ -57,7 +57,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -218,7 +218,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -241,6 +241,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -279,7 +288,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -342,7 +351,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
+    assert(move(balance) == 100, 4);
     return;
 }
 
@@ -383,7 +392,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 4);    
+    assert(move(balance) == 200, 4);
     return;
 }
 
@@ -399,13 +408,13 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 1);    
+    assert(move(balance) == 200, 1);
     return;
 }
 
 //! new-transaction
 //! sender: bob
-// Bob publishes EToken and Capability under his account. 
+// Bob publishes EToken and Capability under his account.
 
 import {{alice}}.Capability;
 import {{alice}}.EToken;
@@ -430,7 +439,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 0, 1);    
+    assert(move(balance) == 0, 1);
     return;
 }
 

--- a/testscripts/5_regular_user_can_transfer_token.mvir
+++ b/testscripts/5_regular_user_can_transfer_token.mvir
@@ -1,9 +1,9 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
-// This set of transaction tests the following scenario 
+// This set of transaction tests the following scenario
 //      Alice mints token and transfer to Bob
 //      Bob transfers some back to Alice, balance is updated correctly.
 
@@ -55,7 +55,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -216,7 +216,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -239,6 +239,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -277,7 +286,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -340,7 +349,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
+    assert(move(balance) == 100, 4);
     return;
 }
 
@@ -381,7 +390,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 4);    
+    assert(move(balance) == 200, 4);
     return;
 }
 
@@ -397,13 +406,13 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 1);    
+    assert(move(balance) == 200, 1);
     return;
 }
 
 //! new-transaction
 //! sender: bob
-// Bob publishes EToken and Capability under his account. 
+// Bob publishes EToken and Capability under his account.
 
 import {{alice}}.Capability;
 import {{alice}}.EToken;
@@ -428,7 +437,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 0, 1);    
+    assert(move(balance) == 0, 1);
     return;
 }
 
@@ -465,7 +474,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 101, 1);    
+    assert(move(balance) == 101, 1);
     return;
 }
 
@@ -481,7 +490,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 99, 1);    
+    assert(move(balance) == 99, 1);
     return;
 }
 
@@ -517,7 +526,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 111, 1);    
+    assert(move(balance) == 111, 1);
     return;
 }
 

--- a/testscripts/7_granted_minter_can_mint.mvir
+++ b/testscripts/7_granted_minter_can_mint.mvir
@@ -1,11 +1,11 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
-// This set of transaction tests the following scenario 
+// This set of transaction tests the following scenario
 //      Alice grants minting capability to Bob
-//      Bob mints some tokens and checks if the balance is updated correctly. 
+//      Bob mints some tokens and checks if the balance is updated correctly.
 
 //! account: alice
 //! account: bob
@@ -55,7 +55,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -216,7 +216,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -239,6 +239,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -277,7 +286,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -311,7 +320,7 @@ main(){
     // Publish initial capability and Token
     Capability.publish();
     EToken.publish();
- 
+
     return;
 }
 
@@ -327,7 +336,7 @@ main(){
     // Publish initial capability and Token
     Capability.publish();
     EToken.publish();
- 
+
     return;
 }
 
@@ -345,7 +354,7 @@ main(){
     owner_capability = Capability.borrow_owner_capability();
 
     // Delegate itself as a minter
-    Capability.grant_minter_capability({{bob}}, move(owner_capability));  
+    Capability.grant_minter_capability({{bob}}, move(owner_capability));
 
     return;
 }
@@ -377,6 +386,6 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
-    return;    
+    assert(move(balance) == 100, 4);
+    return;
 }

--- a/testscripts/8_transfer_token_to_a_user_that_hasnt_published.mvir
+++ b/testscripts/8_transfer_token_to_a_user_that_hasnt_published.mvir
@@ -1,10 +1,10 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
 // This set of transaction tests the following scenario:
-//      Alice mints some coin and transfer to Bob. 
+//      Alice mints some coin and transfer to Bob.
 //      Note that in this case Bob hasn't published the coin on his account yet.
 //      This will fail with MissingData,
 //      as there's no eToken resource in Bob's address.
@@ -57,7 +57,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -218,7 +218,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -241,6 +241,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -279,7 +288,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -342,7 +351,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
+    assert(move(balance) == 100, 4);
     return;
 }
 

--- a/testscripts/9_regular_user_can_burn_his_tokens.mvir
+++ b/testscripts/9_regular_user_can_burn_his_tokens.mvir
@@ -1,16 +1,6 @@
-// -----------------------------------------------------------------
-//  Developed by Quantstamp
-//                           for eToro Libra token audit
-// -----------------------------------------------------------------
-
-// This set of transaction tests the following scenario
-//      Alice mints token and transfers to Bob
-//      Bob transfers some token to Alice and succeeded
-//      Alice blacklists Bob.
-//      Bob tries to transfer some token to Alice,
-//      this should fail on:
-//          assert(move(is_not_blacklisted), 2);
-//      in the function require_not_blacklisted()
+// This set of transaction tests the following scenario:
+//      Alice deploys the module, proves ownership and mints token
+//      Alice burns tokens and checks that the balance matches
 
 //! account: alice
 //! account: bob
@@ -51,8 +41,7 @@ module Capability {
 
         // Publish owner capability if sender is the privileged account
         // Uncomment the following line in production and use a real owner account: if (move(sender) == 0x0) {
-        //if (true) {
-        if (move(sender) == {{alice}}) {
+        if (true) {
             // Always branch to here when testing, otherwise the test can't complete as the sender address is randomly chosen.
             Self.grant_owner_capability();
         }
@@ -112,7 +101,7 @@ module Capability {
         return;
     }
 
-    // Revoke minter capability from receiver, but can only succeed if sender owns the owner capability.  
+    // Revoke minter capability from receiver, but can only succeed if sender owns the owner capability.
     public revoke_minter_capability(revokee: address, owner_capability: &R#Self.Owner) {
         let capability_ref: &mut R#Self.T;
 
@@ -139,7 +128,7 @@ module Capability {
         return;
     }
 
-    // Revoke blacklist capability from receiver, but can only succeed if sender owns the owner capability.         
+    // Revoke blacklist capability from receiver, but can only succeed if sender owns the owner capability.
     public revoke_blacklisted_capability(revokee: address, owner_capability: &R#Self.Owner) {
         let capability_ref: &mut R#Self.T;
 
@@ -200,7 +189,7 @@ module Capability {
     public require_minter(capability: &R#Self.T) {
         let is_minter: bool;
         is_minter = Self.is_minter(move(capability));
-        assert(move(is_minter), 1);
+        assert(move(is_minter), 0);
         return;
     }
 
@@ -208,7 +197,7 @@ module Capability {
     public require_not_blacklisted(capability: &R#Self.T) {
         let is_not_blacklisted: bool;
         is_not_blacklisted = Self.is_not_blacklisted(move(capability));
-        assert(move(is_not_blacklisted), 2);
+        assert(move(is_not_blacklisted), 0);
         return;
     }
 }
@@ -304,14 +293,13 @@ module EToken {
         value = *(&copy(sender_token_ref).value);
 
         // Make sure that sender has enough tokens
-        assert(copy(value) >= copy(amount), 3);
+        assert(copy(value) >= copy(amount), 1);
 
         // Split the senders token and return the amount specified
         *(&mut move(sender_token_ref).value) = move(value) - copy(amount);
         return T{ value: move(amount) };
     }
 }
-
 
 //! new-transaction
 //! sender: alice
@@ -358,52 +346,33 @@ main(){
     return;
 }
 
-
 //! new-transaction
 //! sender: alice
-// Alice mint again, reaching 200
-
+// Alice burns another 50 tokens by resource
 
 import {{alice}}.Capability;
 import {{alice}}.EToken;
 
 main(){
-    let sender: address;
-    let owner_capability: &R#Capability.Owner;
-    let capability_1: &R#Capability.T;
-    let capability_2: &R#Capability.T;
-    let minted_tokens: R#EToken.T;
+    let withdrawn_tokens: R#EToken.T;
+    let capability: &R#Capability.T;
     let balance: u64;
+    // Test that the balance corresponds with the intended behaviour
+    capability = Capability.borrow_capability();
 
-    sender = get_txn_sender();
+    withdrawn_tokens = EToken.withdraw(50, move(capability));
 
-    // Borrow owner_capability for minter delegation
-    owner_capability = Capability.borrow_owner_capability();
-
-    // Delegate itself as a minter
-    Capability.grant_minter_capability(copy(sender), move(owner_capability));
-
-    // Borrow general capability for proof of minting capability
-    capability_1 = Capability.borrow_capability();
-
-    // Mint 100 eTokens and prove minter capability
-    minted_tokens = EToken.mint(100, move(capability_1));
-
-    // Deposit the freshly minted tokens to itself
-    capability_2 = Capability.borrow_capability();
-    EToken.deposit(move(sender), move(minted_tokens), move(capability_2));
-
+    EToken.burn(move(withdrawn_tokens));
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 4);
+    assert(move(balance) == 50, 4);
     return;
 }
 
 //! new-transaction
 //! sender: alice
-// Alice checks her account has 200 eToken
+// Alice checks her account has 50 eToken
 
-import {{alice}}.Capability;
 import {{alice}}.EToken;
 
 main(){
@@ -411,165 +380,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 1);
+    assert(move(balance) == 50, 1);
     return;
 }
 
-//! new-transaction
-//! sender: bob
-// Bob publishes EToken and Capability under his account.
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-    // Publish initial capability
-    Capability.publish();
-    // Publish eToken
-    EToken.publish();
-    return;
-}
-
-//! new-transaction
-//! sender: bob
-// Bob checks his account has 0 eToken
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-    let balance: u64;
-
-    // Test that the balance corresponds with the intended behaviour
-    balance = EToken.balance();
-    assert(move(balance) == 0, 1);
-    return;
-}
-
-//! new-transaction
-//! sender: alice
-// Alice transfers 99 EToken to Bob
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-
-    let etk_coin: R#EToken.T;
-    let etk_cap: &R#Capability.T;
-    // Test that the balance corresponds with the intended behaviour
-    etk_cap = Capability.borrow_capability();
-
-    etk_coin = EToken.withdraw(99, copy(etk_cap));
-    // deposit(payee: address, to_deposit: R#Self.T, capability: &R#Capability.T)
-    EToken.deposit({{bob}}, move(etk_coin), move(etk_cap));
-    return;
-}
-
-
-//! new-transaction
-//! sender: alice
-// Alice checks her account has 101 eToken
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-    let balance: u64;
-
-    // Test that the balance corresponds with the intended behaviour
-    balance = EToken.balance();
-    assert(move(balance) == 101, 1);
-    return;
-}
-
-//! new-transaction
-//! sender: bob
-// Bob checks his account has 99 eToken
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-    let balance: u64;
-
-    // Test that the balance corresponds with the intended behaviour
-    balance = EToken.balance();
-    assert(move(balance) == 99, 1);
-    return;
-}
-
-//! new-transaction
-//! sender: bob
-// Bob transfers 10 EToken to Alice
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-
-    let etk_coin: R#EToken.T;
-    let etk_cap: &R#Capability.T;
-    // Test that the balance corresponds with the intended behaviour
-    etk_cap = Capability.borrow_capability();
-
-    etk_coin = EToken.withdraw(10, copy(etk_cap));
-    // deposit(payee: address, to_deposit: R#Self.T, capability: &R#Capability.T)
-    EToken.deposit({{alice}}, move(etk_coin), move(etk_cap));
-    return;
-}
-
-//! new-transaction
-//! sender: alice
-// Alice checks her account has 111 eToken
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-    let balance: u64;
-
-    // Test that the balance corresponds with the intended behaviour
-    balance = EToken.balance();
-    assert(move(balance) == 111, 1);
-    return;
-}
-
-//! new-transaction
-//! sender: alice
-// Alice transfers 99 EToken to Bob
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-
-    let etk_owner_cap: &R#Capability.Owner;
-    // Test that the balance corresponds with the intended behaviour
-    etk_owner_cap = Capability.borrow_owner_capability();
-    Capability.grant_blacklisted_capability({{bob}}, move(etk_owner_cap));
-
-    return;
-}
-
-//! new-transaction
-//! sender: bob
-// Bob transfers 10 EToken to Alice
-
-import {{alice}}.Capability;
-import {{alice}}.EToken;
-
-main(){
-
-    let etk_coin: R#EToken.T;
-    let etk_cap: &R#Capability.T;
-    // Test that the balance corresponds with the intended behaviour
-    etk_cap = Capability.borrow_capability();
-
-    etk_coin = EToken.withdraw(10, copy(etk_cap));
-    // deposit(payee: address, to_deposit: R#Self.T, capability: &R#Capability.T)
-    EToken.deposit({{alice}}, move(etk_coin), move(etk_cap));
-    return;
-}
-
-// check: Aborted(2)

--- a/testscripts/f1_owner_can_blacklist_himself.mvir
+++ b/testscripts/f1_owner_can_blacklist_himself.mvir
@@ -1,9 +1,9 @@
 // -----------------------------------------------------------------
-//  Developed by Quantstamp 
+//  Developed by Quantstamp
 //                           for eToro Libra token audit
 // -----------------------------------------------------------------
 
-// This set of transaction tests the following scenario 
+// This set of transaction tests the following scenario
 //      Alice blacklists herself and tries to send tokens afterwards
 //      this would fail on :
 //              assert(move(is_not_blacklisted), 2);
@@ -57,7 +57,7 @@ module Capability {
         // Publish a new capability with no permissions.
         move_to_sender<T>(T{ minter: false, blacklisted: false, available_mint: 0 });
 
-        return;    
+        return;
     }
 
     // Internal function that grants owner capability
@@ -218,7 +218,7 @@ module EToken {
 
     // This module is responsible for an actual eToken.
     // For it to be useful a capability has to be published by using the Capability module above.
-    
+
     // -----------------------------------------------------------------
 
     import {{alice}}.Capability;
@@ -241,6 +241,15 @@ module EToken {
         Capability.require_minter(move(capability));
         Capability.check_and_decrease_available_mint(copy(value));
         return T{value: move(value)};
+    }
+
+    // Burn owned tokens
+    public burn(to_burn: R#Self.T) {
+        let to_burn_value: u64;
+
+        // Unpack and destroy tokens
+        T { value: to_burn_value } = move(to_burn);
+        return;
     }
 
     // Returns an account's eToken balance.
@@ -279,7 +288,7 @@ module EToken {
     }
 
     // Withdraw an amount of tokens of the sender and return it.
-    // This works by splitting the token published and returning the specified amount as tokens. 
+    // This works by splitting the token published and returning the specified amount as tokens.
     public withdraw(amount: u64, capability: &R#Capability.T): R#Self.T {
         let sender: address;
         let sender_token_ref: &mut R#Self.T;
@@ -342,7 +351,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 100, 4);    
+    assert(move(balance) == 100, 4);
     return;
 }
 
@@ -383,7 +392,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 4);    
+    assert(move(balance) == 200, 4);
     return;
 }
 
@@ -399,13 +408,13 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 200, 1);    
+    assert(move(balance) == 200, 1);
     return;
 }
 
 //! new-transaction
 //! sender: bob
-// Bob publishes EToken and Capability under his account. 
+// Bob publishes EToken and Capability under his account.
 
 import {{alice}}.Capability;
 import {{alice}}.EToken;
@@ -430,7 +439,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 0, 1);    
+    assert(move(balance) == 0, 1);
     return;
 }
 
@@ -467,7 +476,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 101, 1);    
+    assert(move(balance) == 101, 1);
     return;
 }
 
@@ -483,7 +492,7 @@ main(){
 
     // Test that the balance corresponds with the intended behaviour
     balance = EToken.balance();
-    assert(move(balance) == 99, 1);    
+    assert(move(balance) == 99, 1);
     return;
 }
 


### PR DESCRIPTION
I added a burn method and the following tests:

- Alice deploys the module, proves ownership and mints tokens to her account
- Alice burns tokens, and it is checked that the correct amount matches the balance 

You can find a cli implementation for manual tests here: https://github.com/stablyio/USDS_Libra

Still todo:

- decide whether capability should be passed to revert burns if a user is blacklisted for example
- Test that burning more that Alice balance should fail ( I could not get the `6_blacklisted_user_transfer_token_should_fail.mvir` script to work
- Test that burning negative amount is not possible
- Test that burning from Burner that has not published yet fails

Looking forward to getting your feedback and make changes accordingly.
